### PR TITLE
minor fix in check_length() error message

### DIFF
--- a/sup_tutorial/resnet18_cifar10_SE_solution.ipynb
+++ b/sup_tutorial/resnet18_cifar10_SE_solution.ipynb
@@ -371,7 +371,7 @@
       "source": [
         "def check_length(length, value, name):\n",
         "  if len(value) != length:\n",
-        "    raise ValueError(f\"`{name}` must be of length 4 not {len(value)}\")\n",
+        "    raise ValueError(f\"`{name}` must be of length {length} not {len(value)}\")\n",
         "\n",
         "class BlockV2(hk.Module):\n",
         "  \"\"\"ResNet V2 block with optional bottleneck.\"\"\"\n",

--- a/sup_tutorial/resnet18_cifar10_adversarial.ipynb
+++ b/sup_tutorial/resnet18_cifar10_adversarial.ipynb
@@ -150,7 +150,7 @@
         "#@title Define the model: Resnet18\n",
         "def check_length(length, value, name):\n",
         "  if len(value) != length:\n",
-        "    raise ValueError(f\"`{name}` must be of length 4 not {len(value)}\")\n",
+        "    raise ValueError(f\"`{name}` must be of length {length} not {len(value)}\")\n",
         "\n",
         "class BlockV2(hk.Module):\n",
         "  \"\"\"ResNet V2 block with optional bottleneck.\"\"\"\n",

--- a/sup_tutorial/resnet18_cifar10_adversarial_solution.ipynb
+++ b/sup_tutorial/resnet18_cifar10_adversarial_solution.ipynb
@@ -150,7 +150,7 @@
         "#@title Define the model: Resnet18\n",
         "def check_length(length, value, name):\n",
         "  if len(value) != length:\n",
-        "    raise ValueError(f\"`{name}` must be of length 4 not {len(value)}\")\n",
+        "    raise ValueError(f\"`{name}` must be of length {length} not {len(value)}\")\n",
         "\n",
         "class BlockV2(hk.Module):\n",
         "  \"\"\"ResNet V2 block with optional bottleneck.\"\"\"\n",

--- a/sup_tutorial/resnet18_cifar10_baseline_solution.ipynb
+++ b/sup_tutorial/resnet18_cifar10_baseline_solution.ipynb
@@ -334,7 +334,7 @@
       "source": [
         "def check_length(length, value, name):\n",
         "  if len(value) != length:\n",
-        "    raise ValueError(f\"`{name}` must be of length 4 not {len(value)}\")\n",
+        "    raise ValueError(f\"`{name}` must be of length {length} not {len(value)}\")\n",
         "\n",
         "class BlockV2(hk.Module):\n",
         "  \"\"\"ResNet V2 block with optional bottleneck.\"\"\"\n",


### PR DESCRIPTION
A (very) minor fix in check_length(). While most of the code checks against the value length=4, in one occasion for `SEBlock` is against 2, thus resulting in an incorrect error message upon failure.

![immagine](https://user-images.githubusercontent.com/107715/104199382-a8f4b800-5427-11eb-9311-e95ea341732a.png)
